### PR TITLE
Set Nuke Games as inactive

### DIFF
--- a/estudios-mexico.json
+++ b/estudios-mexico.json
@@ -708,7 +708,7 @@
       "state": "",
       "city": "CDMX",
       "type": "Estudio",
-      "inactive": false,
+      "inactive": true,
       "last_time_active": "2021-02-21T23:54:02.104Z",
       "twitter": "",
       "facebook": "",


### PR DESCRIPTION
Pone a Nuke Games como inactivo por que al checarlo con el  site-checker marca error y manualmente muestra lo siguiente: 
`An error occurred during a connection to www.nukegames.mx. PR_END_OF_FILE_ERROR`